### PR TITLE
Allow setting JWT decode kwargs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ from pydantic import BaseModel
 
 from fastapi_resource_server import JwtDecodeOptions, OidcResourceServer
 
-app = FastAPI()
+decode_options = JwtDecodeOptions(require_aud=True, require_issuer=True)
+decode_kwargs = JwtKwargs(audience="my-client", issuer="http://localhost:8888/auth/realms/master")
 
-decode_options = JwtDecodeOptions(verify_aud=False)
+app = FastAPI(swagger_ui_init_oauth={"clientId": decode_kwargs.audience})
 
 auth_scheme = OidcResourceServer(
-    "http://localhost:8888/auth/realms/master",
+    decode_kwargs.issuer,
     scheme_name="Keycloak",
     jwt_decode_options=decode_options,
 )


### PR DESCRIPTION
Hello

I've made a PR to update a few things:

* Allow passing values to validate against the token
* Update example to verify audience and issuer, and pass client ID to swagger documentation to make it easier to play around with the backend

These changes allow you to have a more secure setup since the audience and issuer can then be verified. I also updated the README to have these changes, to ensure that the example follow best practice.

The JwtDecodeOptions model were also not defaulting to None, so I updated it so you don't need to specify None on the once not in use.